### PR TITLE
임시적으로 CORS 허용 설정을 추가한다.

### DIFF
--- a/src/main/java/com/somartreview/reviewmate/config/WebConfig.java
+++ b/src/main/java/com/somartreview/reviewmate/config/WebConfig.java
@@ -1,0 +1,18 @@
+package com.somartreview.reviewmate.config;
+
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+public class WebConfig implements WebMvcConfigurer {
+
+    /*
+    * Allow all CORS for dev environment
+     */
+  @Override
+  public void addCorsMappings(CorsRegistry registry) {
+    registry.addMapping("/**")
+      .allowedOrigins("*")
+      .allowedMethods("*")
+      .allowCredentials(true);
+  }
+}


### PR DESCRIPTION
# 요약
CORS 허용 관리 설정을 추가하고, 로컬 개발 환경에서 서버를 사용할 수 있도록 임시적으로 모든 CORS를 허용합니다.
