### PR TITLE
사진과 함께 리뷰를 업로드할 때 발생하는 버그를 해결한다.

### DIFF
--- a/src/main/java/com/somartreview/reviewmate/config/GlobalControllerAdvice.java
+++ b/src/main/java/com/somartreview/reviewmate/config/GlobalControllerAdvice.java
@@ -80,60 +80,60 @@ public class GlobalControllerAdvice {
     @ExceptionHandler({HttpMessageNotReadableException.class})
     public ResponseEntity<ExceptionResponse> handleMismatchedInput(Exception e) {
         log.warn(INVALID_PROPERTY_ERROR.toString() + " : " + e.getMessage());
-        log.error(e.toString());
+        log.error(e.getCause().getCause().getMessage());
 
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                 .body(ExceptionResponse.builder()
                         .code(INVALID_PROPERTY_ERROR.getCode())
-                        .message(INVALID_PROPERTY_ERROR.toString() + " : " + "잘못된 요청입니다. " + e.toString())
+                        .message(INVALID_PROPERTY_ERROR.toString() + " : " + "잘못된 요청입니다. " + e.getCause().getCause().getMessage())
                         .build());
     }
 
     @ExceptionHandler(NoHandlerFoundException.class)
     public ResponseEntity<ExceptionResponse> noHandlerFoundHandle(NoHandlerFoundException e) {
         log.warn(API_NOT_FOUND_ERROR.toString() + " : " + e.getMessage());
-        log.error(e.toString());
+        log.error(e.getCause().getCause().getMessage());
 
         return ResponseEntity.status(HttpStatus.NOT_FOUND)
                 .body(ExceptionResponse.builder()
                         .code(API_NOT_FOUND_ERROR.getCode())
-                        .message(API_NOT_FOUND_ERROR.toString() + " : " + "처리할 수 없는 요청입니다. " + e.toString())
+                        .message(API_NOT_FOUND_ERROR.toString() + " : " + "처리할 수 없는 요청입니다. " + e.getCause().getCause().getMessage())
                         .build());
     }
 
     @ExceptionHandler(DataIntegrityViolationException.class)
     public ResponseEntity<ExceptionResponse> handleDataIntegrityViolation(DataIntegrityViolationException e) {
         log.warn(DB_CONFLICT_ERROR.toString() + " : " + e.getMessage());
-        log.warn(DB_CONFLICT_ERROR.getMessage() + " : " + e.getCause().getMessage());
+        log.warn(DB_CONFLICT_ERROR.getMessage() + " : " + e.getCause().getCause().getMessage());
 
         return ResponseEntity.status(HttpStatus.CONFLICT)
                 .body(ExceptionResponse.builder()
                         .code(DB_CONFLICT_ERROR.getCode())
-                        .message(DB_CONFLICT_ERROR.toString() + " : " + DB_CONFLICT_ERROR.getMessage() + " : " + e.getCause().getMessage())
+                        .message(DB_CONFLICT_ERROR.toString() + " : " + DB_CONFLICT_ERROR.getMessage() + " : " + e.getCause().getCause().getMessage())
                         .build());
     }
 
     @ExceptionHandler(ReviewMateException.class)
     public ResponseEntity<ExceptionResponse> handleReviewMateException(ReviewMateException e) {
         log.warn(e.getErrorCode().toString() + " : " + e.getMessage());
-        log.error(e.toString());
+        log.error(e.getCause().getCause().getMessage());
 
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                 .body(ExceptionResponse.builder()
                         .code(e.getErrorCode().getCode())
-                        .message(e.getErrorCode().toString() + " : " + e.getMessage() + ". " + e.toString())
+                        .message(e.getErrorCode().toString() + " : " + e.getMessage() + ". " + e.getCause().getCause().getMessage())
                         .build());
     }
 
     @ExceptionHandler(RuntimeException.class)
     public ResponseEntity<ExceptionResponse> handleRuntimeException(RuntimeException e) {
         log.warn(RUNTIME_ERROR.toString() + " : " + RUNTIME_ERROR.getMessage());
-        log.error(e.toString());
+        log.error(e.getCause().getCause().getMessage());
 
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
                 .body(ExceptionResponse.builder()
                         .code(RUNTIME_ERROR.getCode())
-                        .message(RUNTIME_ERROR.toString() + " : " + RUNTIME_ERROR.getMessage() + ". " + e.toString())
+                        .message(RUNTIME_ERROR.toString() + " : " + RUNTIME_ERROR.getMessage() + ". " + e.getCause().getCause().getMessage())
                         .build());
     }
 }

--- a/src/main/java/com/somartreview/reviewmate/domain/review/ReviewImage.java
+++ b/src/main/java/com/somartreview/reviewmate/domain/review/ReviewImage.java
@@ -29,14 +29,19 @@ public class ReviewImage extends BaseEntity {
     private Review review;
 
     @Builder
-    public ReviewImage(String url) {
+    public ReviewImage(String url, Review review) {
         validateUrl(url);
         this.url = url;
+        this.review = review;
     }
 
     private void validateUrl(final String url) {
         if (url.isBlank() || url.length() > MAX_URL_LENGTH) {
             throw new DomainLogicException(ErrorCode.REVIEW_IMAGE_URL_ERROR);
         }
+    }
+
+    public void setReview(Review review) {
+        this.review = review;
     }
 }

--- a/src/test/java/com/somartreview/reviewmate/domain/review/ReviewImageTest.java
+++ b/src/test/java/com/somartreview/reviewmate/domain/review/ReviewImageTest.java
@@ -13,9 +13,10 @@ class ReviewImageTest {
     void 리뷰이미지의_url은_공백이어선_안된다() {
         // given
         String url = " ";
+        Review mockReview = new Review();
 
         // when & then
-        assertThatThrownBy(() -> new ReviewImage(url))
+        assertThatThrownBy(() -> new ReviewImage(url, mockReview))
                 .isInstanceOf(DomainLogicException.class)
                 .hasMessageContaining(REVIEW_IMAGE_URL_ERROR.getMessage());
     }
@@ -24,9 +25,10 @@ class ReviewImageTest {
     void 리뷰이미지의_url은_1024자_보다_길면_안된다() {
         // given
         String url = "a".repeat(1025);
+        Review mockReview = new Review();
 
         // when & then
-        assertThatThrownBy(() -> new ReviewImage(url))
+        assertThatThrownBy(() -> new ReviewImage(url, mockReview))
                 .isInstanceOf(DomainLogicException.class)
                 .hasMessageContaining(REVIEW_IMAGE_URL_ERROR.getMessage());
     }

--- a/src/test/java/com/somartreview/reviewmate/domain/review/ReviewTest.java
+++ b/src/test/java/com/somartreview/reviewmate/domain/review/ReviewTest.java
@@ -172,9 +172,11 @@ class ReviewTest {
     @Test
     void 리뷰에_리뷰이미지를_설정한다() {
         // given
+        Review mockReview1 = new Review();
+        Review mockReview2 = new Review();
         List<ReviewImage> reviewImages = new ArrayList<>(Arrays.asList(
-                new ReviewImage("www.image1.com"),
-                new ReviewImage("www.image2.com")
+                new ReviewImage("www.image1.com", mockReview1),
+                new ReviewImage("www.image2.com", mockReview2)
         ));
 
         // then


### PR DESCRIPTION
# 요약

### 사진과 함께 리뷰를 업로드할 때 발생하는 버그를 해결했습니다. ReviewImage 엔티티에 Review가 제대로 등록되지 않는 부분을 해결했습니다.
<img width="964" alt="KakaoTalk_Photo_2023-09-26-04-06-42" src="https://github.com/review-mate/review-mate-be/assets/49567744/b33535c3-480d-4435-bc19-3cf80a760d23">

> src/main/java/com/somartreview/reviewmate/service/review/ReviewService.java
```java
private List<ReviewImage> createReviewImages(List<MultipartFile> reviewImageFiles, Review review) {
        return reviewImageFiles.stream()
                .map(reviewImageFile -> ReviewImage.builder()
                        .url(uploadReviewImageOnS3(reviewImageFile))
                        .review(review)
                        .build())
                .toList();
    }
```



### 추가적으로 에러 메시지가 충분히 자세하지 않은 점을 해결하기 위해
<img width="753" alt="KakaoTalk_Photo_2023-09-26-04-06-37" src="https://github.com/review-mate/review-mate-be/assets/49567744/b731d3af-c89e-4eb9-b1a6-42e139ee58e8">

내부 ExceptionHandler의 내용을 메시지에 첨부하였습니다.
![스크린샷 2023-09-26 04 02 58](https://github.com/review-mate/review-mate-be/assets/49567744/0dc83cff-3a02-4fbd-9a81-a3bf9e600760)


> src/main/java/com/somartreview/reviewmate/config/GlobalControllerAdvice.java
```java
@ExceptionHandler(DataIntegrityViolationException.class)
    public ResponseEntity<ExceptionResponse> handleDataIntegrityViolation(DataIntegrityViolationException e) {
        log.warn(DB_CONFLICT_ERROR.toString() + " : " + e.getMessage());
        log.warn(DB_CONFLICT_ERROR.getMessage() + " : " + e.getCause().getMessage());

        return ResponseEntity.status(HttpStatus.CONFLICT)
                .body(ExceptionResponse.builder()
                        .code(DB_CONFLICT_ERROR.getCode())
                        .message(DB_CONFLICT_ERROR.toString() + " : " + DB_CONFLICT_ERROR.getMessage() + " : " + e.getCause().getMessage())
                        .build());
    }
```

# 체크리스트
이 PR에는:

- [X] 버그 해결
- [X] 예외 해결에 도움이 되도록, 에러 메시지 추가
