### PR TITLE
Swagger 문서에 https aws 서버 주소를 추가한다.

### DIFF
--- a/src/main/java/com/somartreview/reviewmate/config/SwaggerConfig.java
+++ b/src/main/java/com/somartreview/reviewmate/config/SwaggerConfig.java
@@ -1,5 +1,7 @@
 package com.somartreview.reviewmate.config;
 
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.servers.Server;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.OpenAPI;
@@ -7,6 +9,10 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+@OpenAPIDefinition(servers = {
+        @Server(url = "https://api.reviewmate.co.kr", description = "AWS server URL"),
+        @Server(url = "http://localhost:8080", description = "Default local server URL")
+})
 @Configuration
 public class SwaggerConfig {
 


### PR DESCRIPTION
# 요약
HTTPS AWS 서버가 추가됨에 따라, 기존의 Swagger가 http server url만 지원하던 것을 변경했습니다.

![스크린샷 2023-10-11 14 43 51](https://github.com/review-mate/review-mate-be/assets/49567744/7ca3ede6-a9a4-49a0-8724-e42c0c4ed1ab)


# 체크리스트
이 PR에는:

- [x] swagger 문서에 aws url과 localhost url 추가
- [x] aws url을 디폴트로 설정
