### PR TITLE
상품에 등록된 리뷰가 분석된 리뷰태그의 속성/키워드(분류데이터)를 조회한다.

### DIFF
--- a/src/main/java/com/somartreview/reviewmate/config/SwaggerConfig.java
+++ b/src/main/java/com/somartreview/reviewmate/config/SwaggerConfig.java
@@ -1,5 +1,7 @@
 package com.somartreview.reviewmate.config;
 
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.servers.Server;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.OpenAPI;
@@ -7,6 +9,10 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+@OpenAPIDefinition(servers = {
+        @Server(url = "https://api.reviewmate.co.kr", description = "AWS server URL"),
+        @Server(url = "http://localhost:8080", description = "Default local server URL")
+})
 @Configuration
 public class SwaggerConfig {
 

--- a/src/main/java/com/somartreview/reviewmate/domain/review/ReviewTag.java
+++ b/src/main/java/com/somartreview/reviewmate/domain/review/ReviewTag.java
@@ -1,5 +1,6 @@
 package com.somartreview.reviewmate.domain.review;
 
+import com.querydsl.core.annotations.QueryInit;
 import com.somartreview.reviewmate.domain.BaseEntity;
 import com.somartreview.reviewmate.exception.DomainLogicException;
 import com.somartreview.reviewmate.exception.ErrorCode;
@@ -39,6 +40,7 @@ public class ReviewTag extends BaseEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "review_id", nullable = false)
+    @QueryInit("reservation.travelProduct")
     private Review review;
 
     @Builder

--- a/src/main/java/com/somartreview/reviewmate/domain/review/ReviewTagCustomRepository.java
+++ b/src/main/java/com/somartreview/reviewmate/domain/review/ReviewTagCustomRepository.java
@@ -1,0 +1,10 @@
+package com.somartreview.reviewmate.domain.review;
+
+import com.somartreview.reviewmate.dto.review.ReviewTagClassificationDto;
+
+import java.util.List;
+
+public interface ReviewTagCustomRepository {
+
+    List<ReviewTagClassificationDto> getDistinctReviewTagClassificationsByTravelProductId(Long travelProductId);
+}

--- a/src/main/java/com/somartreview/reviewmate/domain/review/ReviewTagCustomRepositoryImpl.java
+++ b/src/main/java/com/somartreview/reviewmate/domain/review/ReviewTagCustomRepositoryImpl.java
@@ -1,0 +1,34 @@
+package com.somartreview.reviewmate.domain.review;
+
+import com.querydsl.core.Tuple;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.somartreview.reviewmate.dto.review.ReviewTagClassificationDto;
+
+import javax.persistence.EntityManager;
+import java.util.*;
+
+import static com.somartreview.reviewmate.domain.review.QReviewTag.reviewTag;
+
+public class ReviewTagCustomRepositoryImpl implements ReviewTagCustomRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    public ReviewTagCustomRepositoryImpl(EntityManager em) {
+        this.queryFactory = new JPAQueryFactory(em);
+    }
+
+
+    @Override
+    public List<ReviewTagClassificationDto> getDistinctReviewTagClassificationsByTravelProductId(Long travelProductId) {
+        List<Tuple> groupByTags = queryFactory
+                .select(reviewTag.reviewProperty, reviewTag.keyword)
+                .from(reviewTag)
+                .where(reviewTag.review.reservation.travelProduct.id.eq(travelProductId))
+                .groupBy(reviewTag.reviewProperty, reviewTag.keyword)
+                .fetch();
+
+        return groupByTags.stream().map(tag ->
+                new ReviewTagClassificationDto(tag.get(reviewTag.reviewProperty), tag.get(reviewTag.keyword))
+        ).toList();
+    }
+}

--- a/src/main/java/com/somartreview/reviewmate/domain/review/ReviewTagRepository.java
+++ b/src/main/java/com/somartreview/reviewmate/domain/review/ReviewTagRepository.java
@@ -9,7 +9,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 
 @Repository
-public interface ReviewTagRepository extends JpaRepository<ReviewTag, Long> {
+public interface ReviewTagRepository extends JpaRepository<ReviewTag, Long>, ReviewTagCustomRepository {
 
     List<ReviewTag> findAllByReview_Id(Long reviewId);
 

--- a/src/main/java/com/somartreview/reviewmate/dto/review/ReviewTagClassificationDto.java
+++ b/src/main/java/com/somartreview/reviewmate/dto/review/ReviewTagClassificationDto.java
@@ -1,0 +1,16 @@
+package com.somartreview.reviewmate.dto.review;
+
+import com.somartreview.reviewmate.domain.review.ReviewProperty;
+import lombok.Getter;
+
+@Getter
+public class ReviewTagClassificationDto {
+
+    private String property;
+    private String keyword;
+
+    public ReviewTagClassificationDto(ReviewProperty property, String keyword) {
+        this.property = property.toString();
+        this.keyword = keyword;
+    }
+}

--- a/src/main/java/com/somartreview/reviewmate/service/review/ReviewTagService.java
+++ b/src/main/java/com/somartreview/reviewmate/service/review/ReviewTagService.java
@@ -2,10 +2,12 @@ package com.somartreview.reviewmate.service.review;
 
 import com.somartreview.reviewmate.domain.review.ReviewTag;
 import com.somartreview.reviewmate.domain.review.ReviewTagRepository;
+import com.somartreview.reviewmate.dto.review.ReviewTagClassificationDto;
+import com.somartreview.reviewmate.service.products.TravelProductService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
-import java.util.List;
+import java.util.*;
 
 // Add positiveTags and negativeTags assignment in TravelProduct DTO after implementing reviewTag service
 @Service
@@ -13,9 +15,15 @@ import java.util.List;
 public class ReviewTagService {
 
     private final ReviewTagRepository reviewTagRepository;
+    private final TravelProductService travelProductService;
 
     public List<ReviewTag> findReviewTagsByReviewId(Long reviewId) {
         return reviewTagRepository.findAllByReview_Id(reviewId);
     }
 
+    public List<ReviewTagClassificationDto> getDistinctReviewTagClassificationDtosByPartnerDomainAndTravelProductPartnerCustomId(String partnerDomain, String travelProductPartnerCustomId) {
+        Long travelProductId = travelProductService.findByPartnerDomainAndPartnerCustomId(partnerDomain, travelProductPartnerCustomId).getId();
+
+        return reviewTagRepository.getDistinctReviewTagClassificationsByTravelProductId(travelProductId);
+    }
 }

--- a/src/main/java/com/somartreview/reviewmate/web/review/ReviewTagController.java
+++ b/src/main/java/com/somartreview/reviewmate/web/review/ReviewTagController.java
@@ -1,14 +1,51 @@
 package com.somartreview.reviewmate.web.review;
 
+import com.somartreview.reviewmate.dto.review.ReviewTagClassificationDto;
+import com.somartreview.reviewmate.service.review.ReviewTagService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.*;
+
 // Impl the requests (상품에 달려있는 태그들 조회, 평점+탑 태그와 같은 리뷰 통계)
 @Tag(name = "리뷰 태그 및 감정 분석 데이터")
-@RequestMapping("/api/v1")
+@RequestMapping("/api/widget/v1")
 @RestController
 @RequiredArgsConstructor
 public class ReviewTagController {
+
+    private final ReviewTagService reviewTagService;
+
+
+    @Operation(operationId = "getDistinctReviewTagClassification", summary = "상품에서 필터링할 리뷰의 속성과 키워드 목록 조회", description = "상품에 등록된 리뷰의 분석 결과를 바탕으로 리뷰의 속성과 키워드들을 조회합니다. \n⚠️ 현재는 등록된 모든 속성과 키워드를 조회합니다. (threshold 없음)")
+    @Parameter(name = "partnerDomain", description = "파트너사 도메인", example = "goodchoice.kr")
+    @Parameter(name = "travelProductCustomId", description = "단일 여행상품의 파트너사 커스텀 ID", example = "PRODUCT_0001")
+    @ApiResponse(responseCode = "200", description = "조회 성공")
+    @ApiResponse(responseCode = "400", description = "존재하지 않는 파트너사 도메인 혹은 여행상품 파트너사 커스텀 ID")
+    @GetMapping("{partnerDomain}/products/{travelProductCustomId}/tags")
+    public ResponseEntity<Map<String, Set<String>>> getDistinctReviewTagClassification(@PathVariable String partnerDomain,
+                                                                    @PathVariable String travelProductCustomId) {
+        List<ReviewTagClassificationDto> reviewTagClassificationDtos = reviewTagService.getDistinctReviewTagClassificationDtosByPartnerDomainAndTravelProductPartnerCustomId(partnerDomain, travelProductCustomId);
+
+        Map<String, Set<String>> propertiesKeywords = new HashMap<>();
+        for (ReviewTagClassificationDto dto : reviewTagClassificationDtos) {
+            String property = dto.getProperty();
+            String keyword = dto.getKeyword();
+
+            Set<String> keywords = propertiesKeywords.getOrDefault(property, new HashSet<>());
+            keywords.add(keyword);
+
+            propertiesKeywords.put(property, keywords);
+        }
+
+        return ResponseEntity.ok(propertiesKeywords);
+    }
 }

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -16,10 +16,10 @@ VALUES ('2023-08-30 12:00:00', '2023-08-30 12:00:00', 'sckwon770kakao', '권순�
 --  Client side  #####################################################################################################################################################################################################################
 
 INSERT INTO customer (created_at, updated_at, kakao_id, name, partner_custom_id, phone_number, partner_company_id)
-VALUES ('2023-08-30 12:00:00', '2023-08-30 12:00:00', 'sckwon770kakao', '권순찬', 'CUSTOMER-0001', '010-1234-1234', 1);
+VALUES ('2023-08-30 12:00:00', '2023-08-30 12:00:00', 'sckwon770kakao', '권순찬', 'CUSTOMER_0001', '010-1234-1234', 1);
 
 INSERT INTO travel_product (dtype, created_at, updated_at, name, partner_custom_id, review_count, rating, thumbnail_url, category, partner_company_id, partner_seller_id)
-VALUES ('SingleTravelProduct', '2023-08-30 12:00:00', '2023-08-30 12:00:00', '신라더스테이 호텔 - 스위트룸', 'HOTEL-0001', 1, 5, 'testurl.com', 'ACCOMMODATION', 1, 1);
+VALUES ('SingleTravelProduct', '2023-08-30 12:00:00', '2023-08-30 12:00:00', '신라더스테이 호텔 - 스위트룸', 'PRODUCT_0001', 1, 5, 'testurl.com', 'ACCOMMODATION', 1, 1);
 
 
 --  Review  #####################################################################################################################################################################################################################


### PR DESCRIPTION
# 요약
#19 에서 요청된 기능입니다. 상품 페이지의 리뷰 목록 상단에서 리뷰를 필터링하기 위해 사용할 분류 데이터 조회 기능입니다.
> ## API 요청
> ### 필요 api
> 속성 및 키워드 분류 데이터 아래 참고자료 부분의 개발을 위해 필요합니다.
> 
> ### 데이터 형식
> ```
> {
> 	"property": ["청결", "분위기"],
> 	"keyword": [
> 		["먼지", "냄새"],
> 		["모던", "클래식"]
> 	]
> }
> ```
> 
> ### 참고자료
> > ![image](https://user-images.githubusercontent.com/65444249/270363851-dcbcb64c-fb09-4369-ac8f-971d709f153b.png)

해당 상품에 등록된 리뷰들의 분석결과인 리뷰 태그의 속성, 키워드(분류데이터)를 distinct하게 조회해서 반환합니다. 반환형은 프론트에서 사용하기 쉬운 형태로 제공했습니다.
![스크린샷 2023-10-11 17 42 22](https://github.com/review-mate/review-mate-be/assets/49567744/f3988ea6-f10b-490c-9350-697b81f148da)



# 체크리스트
이 PR에는:

- [X] 요청 추가
