### PR TITLE
AWS S3를 통해 리뷰 사진 기능을 추가한다.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,8 @@ dependencies {
     implementation "com.querydsl:querydsl-apt:${queryDslVersion}"
     implementation 'org.springdoc:springdoc-openapi-ui:1.7.0'
 
+    implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
 

--- a/src/main/java/com/somartreview/reviewmate/config/GlobalControllerAdvice.java
+++ b/src/main/java/com/somartreview/reviewmate/config/GlobalControllerAdvice.java
@@ -2,6 +2,7 @@ package com.somartreview.reviewmate.config;
 
 import com.somartreview.reviewmate.dto.ExceptionResponse;
 import com.somartreview.reviewmate.exception.DomainLogicException;
+import com.somartreview.reviewmate.exception.ExternalServiceException;
 import com.somartreview.reviewmate.exception.ReviewMateException;
 import javax.validation.ConstraintViolation;
 import javax.validation.ConstraintViolationException;
@@ -130,12 +131,24 @@ public class GlobalControllerAdvice {
                         .build());
     }
 
+    @ExceptionHandler(ExternalServiceException.class)
+    public ResponseEntity<ExceptionResponse> handleExternalServiceException(ExternalServiceException e) {
+        log.warn(e.getErrorCode().toString() + " : " + e.getMessage());
+        log.error(e.getCause().getCause().getMessage());
+
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(ExceptionResponse.builder()
+                        .code(e.getErrorCode().getCode())
+                        .message(e.getErrorCode().toString() + " : " + e.getMessage() + ". " + e.getCause().getCause().getMessage())
+                        .build());
+    }
+
     @ExceptionHandler(ReviewMateException.class)
     public ResponseEntity<ExceptionResponse> handleReviewMateException(ReviewMateException e) {
         log.warn(e.getErrorCode().toString() + " : " + e.getMessage());
         log.error(e.getCause().getCause().getMessage());
 
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
                 .body(ExceptionResponse.builder()
                         .code(e.getErrorCode().getCode())
                         .message(e.getErrorCode().toString() + " : " + e.getMessage() + ". " + e.getCause().getCause().getMessage())

--- a/src/main/java/com/somartreview/reviewmate/config/S3Config.java
+++ b/src/main/java/com/somartreview/reviewmate/config/S3Config.java
@@ -1,0 +1,29 @@
+package com.somartreview.reviewmate.config;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class S3Config {
+
+    @Value("${cloud.aws.credentials.accessKey}")
+    private String accessKey;
+    @Value("${cloud.aws.credentials.secretKey}")
+    private String secretKey;
+    @Value("${cloud.aws.s3.region}")
+    private String region;
+
+    @Bean
+    public AmazonS3Client amazonS3Client() {
+        BasicAWSCredentials basicAWSCredentials = new BasicAWSCredentials(accessKey, secretKey);
+        return (AmazonS3Client) AmazonS3ClientBuilder.standard()
+                .withRegion(region)
+                .withCredentials(new AWSStaticCredentialsProvider(basicAWSCredentials))
+                .build();
+    }
+}

--- a/src/main/java/com/somartreview/reviewmate/config/S3Config.java
+++ b/src/main/java/com/somartreview/reviewmate/config/S3Config.java
@@ -11,11 +11,11 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class S3Config {
 
-    @Value("${cloud.aws.credentials.accessKey}")
+    @Value("${cloud.aws.s3.credentials.accessKey}")
     private String accessKey;
-    @Value("${cloud.aws.credentials.secretKey}")
+    @Value("${cloud.aws.s3.credentials.secretKey}")
     private String secretKey;
-    @Value("${cloud.aws.s3.region}")
+    @Value("${cloud.aws.region.static}")
     private String region;
 
     @Bean

--- a/src/main/java/com/somartreview/reviewmate/domain/live/feedback/LiveFeedback.java
+++ b/src/main/java/com/somartreview/reviewmate/domain/live/feedback/LiveFeedback.java
@@ -41,7 +41,8 @@ public class LiveFeedback extends BaseEntity {
     @Column(nullable = false)
     private Boolean isSolved = false;
 
-    @OneToOne(mappedBy = "liveFeedback", fetch = FetchType.EAGER)
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "reservation_id", nullable = false)
     private Reservation reservation;
 
     @Builder

--- a/src/main/java/com/somartreview/reviewmate/domain/live/feedback/LiveFeedbackRepository.java
+++ b/src/main/java/com/somartreview/reviewmate/domain/live/feedback/LiveFeedbackRepository.java
@@ -1,5 +1,6 @@
 package com.somartreview.reviewmate.domain.live.feedback;
 
+import com.somartreview.reviewmate.domain.reservation.Reservation;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -15,8 +16,10 @@ public interface LiveFeedbackRepository extends JpaRepository<LiveFeedback, Long
     @Modifying
     @Query("delete from LiveFeedback lf where lf.id = :id")
     void deleteById(Long id);
+
+
     @Transactional
     @Modifying
-    @Query("delete from LiveFeedback lf where lf.id in :ids")
-    void deleteAllByIdsInQuery(List<Long> ids);
+    @Query("delete from LiveFeedback lf where lf.reservation in :reservations")
+    void deleteAllByReservationsInQuery(List<Reservation> reservations);
 }

--- a/src/main/java/com/somartreview/reviewmate/domain/live/satisfaction/LiveSatisfaction.java
+++ b/src/main/java/com/somartreview/reviewmate/domain/live/satisfaction/LiveSatisfaction.java
@@ -36,7 +36,8 @@ public class LiveSatisfaction extends BaseEntity {
     @Enumerated(STRING)
     private ReviewProperty dissatisfiedReviewProperty;
 
-    @OneToOne(mappedBy = "liveSatisfaction",fetch = FetchType.EAGER)
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "reservation_id", nullable = false)
     private Reservation reservation;
 
     @Builder

--- a/src/main/java/com/somartreview/reviewmate/domain/live/satisfaction/LiveSatisfactionRepository.java
+++ b/src/main/java/com/somartreview/reviewmate/domain/live/satisfaction/LiveSatisfactionRepository.java
@@ -1,5 +1,6 @@
 package com.somartreview.reviewmate.domain.live.satisfaction;
 
+import com.somartreview.reviewmate.domain.reservation.Reservation;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -7,7 +8,6 @@ import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.Optional;
 
 @Repository
 public interface LiveSatisfactionRepository extends JpaRepository<LiveSatisfaction, Long> {
@@ -16,8 +16,10 @@ public interface LiveSatisfactionRepository extends JpaRepository<LiveSatisfacti
     @Modifying
     @Query("delete from LiveSatisfaction ls where ls.id = :id")
     void deleteById(Long id);
+
+
     @Transactional
     @Modifying
-    @Query("delete from LiveSatisfaction ls where ls.id in :ids")
-    void deleteAllByIdsInQuery(List<Long> ids);
+    @Query("delete from LiveSatisfaction ls where ls.reservation in :reservations")
+    void deleteAllByReservationsInQuery(List<Reservation> reservations);
 }

--- a/src/main/java/com/somartreview/reviewmate/domain/product/TravelProduct.java
+++ b/src/main/java/com/somartreview/reviewmate/domain/product/TravelProduct.java
@@ -92,12 +92,12 @@ public abstract class TravelProduct extends BaseEntity {
     }
 
 
-    public void updateReviewData(int newReviewRating) {
+    public void addReviewInfo(int newReviewRating) {
         this.reviewCount++;
         this.rating = (this.rating * (this.reviewCount - 1) + newReviewRating) / this.reviewCount;
     }
 
-    public void removeReviewData(int removedReviewRating) {
+    public void substractReviewInfo(int removedReviewRating) {
         this.reviewCount--;
         if (reviewCount == 0) {
             this.rating = 0.0f;

--- a/src/main/java/com/somartreview/reviewmate/domain/reservation/Reservation.java
+++ b/src/main/java/com/somartreview/reviewmate/domain/reservation/Reservation.java
@@ -45,19 +45,6 @@ public class Reservation extends BaseEntity {
     @JoinColumn(name = "travel_product_id", nullable = false)
     private TravelProduct travelProduct;
 
-    @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "review_id")
-    private Review review;
-
-    @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "live_satisfaction_id")
-    private LiveSatisfaction liveSatisfaction;
-
-    @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "live_feedback_id")
-    private LiveFeedback liveFeedback;
-
-
     @Builder
     public Reservation(String partnerCustomId, LocalDateTime startDateTime, LocalDateTime endDateTime, Customer customer, TravelProduct travelProduct) {
         validatePartnerCustomId(partnerCustomId);
@@ -79,9 +66,5 @@ public class Reservation extends BaseEntity {
         if (startTime.isAfter(endTime)) {
             throw new DomainLogicException(ErrorCode.RESERVATION_FRONT_END_TIME_ERROR);
         }
-    }
-
-    public void addReview(final Review review) {
-        this.review = review;
     }
 }

--- a/src/main/java/com/somartreview/reviewmate/domain/reservation/ReservationRepository.java
+++ b/src/main/java/com/somartreview/reviewmate/domain/reservation/ReservationRepository.java
@@ -15,10 +15,8 @@ import java.util.Optional;
 @Repository
 public interface ReservationRepository extends JpaRepository<Reservation, Long> {
 
+
     Optional<Reservation> findByTravelProduct_PartnerCompany_PartnerDomainAndPartnerCustomId(String partnerDomain, String partnerCustomId);
-
-
-    List<Reservation> findAll();
 
 
     @EntityGraph(attributePaths = {"customer", "travelProduct"})
@@ -31,9 +29,6 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
     @Query("select r from Reservation r " +
             "where r.customer.id = :customerId")
     List<Reservation> findAllByCustomerIdFetchJoin(Long customerId);
-
-
-    List<Reservation> findAllByCustomerId(Long customerId);
 
 
     @EntityGraph(attributePaths = {"customer", "travelProduct"})
@@ -51,35 +46,26 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
     List<Reservation> findAllByTravelProductIdAndCustomerIdFetchJoin(Long travelProductId, Long customerId);
 
 
-    @Query("select r.review.id from Reservation r " +
-            "join r.travelProduct.partnerCompany c " +
+    @Query("select r from Reservation r join r.travelProduct.partnerCompany c " +
             "where r.travelProduct.partnerCompany.partnerDomain = :partnerDomain and r.createdAt >= :dateTime")
-    List<Long> findAllReviewFKsByCreatedAtGreaterThanEqual(String partnerDomain, LocalDateTime dateTime);
+    List<Reservation> findAllByCreatedAtGreaterThanEqual(String partnerDomain, LocalDateTime dateTime);
 
 
-    @Query("select r.review.id from Reservation r " +
-            "join r.travelProduct.partnerCompany c " +
+    @Query("select r from Reservation r join r.travelProduct.partnerCompany c " +
             "left outer join SingleTravelProduct p on r.travelProduct.id = p.id " +
             "where c.partnerDomain = :partnerDomain and p.singleTravelProductCategory = :category and r.createdAt between :startDateTime and :endDateTime")
-    List<Long> findAllReviewFKsByCategoryAndCreatedAtBetween(String partnerDomain, SingleTravelProductCategory category, LocalDateTime startDateTime, LocalDateTime endDateTime);
+    List<Reservation> findAllByCategoryAndCreatedAtBetween(String partnerDomain, SingleTravelProductCategory category, LocalDateTime startDateTime, LocalDateTime endDateTime);
 
 
-    @Query("select r.review.id from Reservation r " +
-            "join r.travelProduct.partnerCompany c " +
+    @Query("select r from Reservation r join r.travelProduct.partnerCompany c " +
             "where r.travelProduct.partnerCompany.partnerDomain = :partnerDomain and r.createdAt between :startDateTime and :endDateTime")
-    List<Long> findAllReviewFKsByCreatedAtBetween(String partnerDomain, LocalDateTime startDateTime, LocalDateTime endDateTime);
+    List<Reservation> findAllByCreatedAtBetween(String partnerDomain, LocalDateTime startDateTime, LocalDateTime endDateTime);
 
 
     @Transactional
     @Modifying
     @Query("delete from Reservation r where r.id = :id")
     void deleteById(Long id);
-
-
-    @Transactional
-    @Modifying
-    @Query("delete from Reservation r where r.id in :ids")
-    void deleteAllByIdsInQuery(List<Long> ids);
 
 
     @Transactional

--- a/src/main/java/com/somartreview/reviewmate/domain/review/Review.java
+++ b/src/main/java/com/somartreview/reviewmate/domain/review/Review.java
@@ -48,7 +48,8 @@ public class Review extends BaseEntity{
     @Enumerated(EnumType.STRING)
     private ReviewPolarity polarity = NEUTRAL;
 
-    @OneToOne(mappedBy = "review", fetch = FetchType.EAGER)
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "reservation_id", nullable = false)
     private Reservation reservation;
 
     @OneToMany(mappedBy = "review")

--- a/src/main/java/com/somartreview/reviewmate/domain/review/Review.java
+++ b/src/main/java/com/somartreview/reviewmate/domain/review/Review.java
@@ -118,6 +118,7 @@ public class Review extends BaseEntity{
 
     public void clearReviewTags() {
         this.reviewTags.clear();
+
         this.positiveTagsCount = 0L;
         this.negativeTagsCount = 0L;
         this.polarity = NEUTRAL;

--- a/src/main/java/com/somartreview/reviewmate/domain/review/ReviewImage.java
+++ b/src/main/java/com/somartreview/reviewmate/domain/review/ReviewImage.java
@@ -14,29 +14,29 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class ReviewImage extends BaseEntity {
 
-    private static final int MAX_URL_LENGTH = 1024;
+    private static final int MAX_URL_LENGTH = 255;
 
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "review_image_id")
     private Long id;
 
-    @Column(nullable = false, length = 1024)
-    private String url;
+    @Column(nullable = false, length = 255)
+    private String fileName;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "review_id", nullable = false)
     private Review review;
 
     @Builder
-    public ReviewImage(String url, Review review) {
-        validateUrl(url);
-        this.url = url;
+    public ReviewImage(String fileName, Review review) {
+        validateFileName(fileName);
+        this.fileName = fileName;
         this.review = review;
     }
 
-    private void validateUrl(final String url) {
-        if (url.isBlank() || url.length() > MAX_URL_LENGTH) {
+    private void validateFileName(final String fileName) {
+        if (fileName.isBlank() || fileName.length() > MAX_URL_LENGTH) {
             throw new DomainLogicException(ErrorCode.REVIEW_IMAGE_URL_ERROR);
         }
     }

--- a/src/main/java/com/somartreview/reviewmate/domain/review/ReviewImage.java
+++ b/src/main/java/com/somartreview/reviewmate/domain/review/ReviewImage.java
@@ -40,8 +40,4 @@ public class ReviewImage extends BaseEntity {
             throw new DomainLogicException(ErrorCode.REVIEW_IMAGE_URL_ERROR);
         }
     }
-
-    public void setReview(Review review) {
-        this.review = review;
-    }
 }

--- a/src/main/java/com/somartreview/reviewmate/domain/review/ReviewImageRepository.java
+++ b/src/main/java/com/somartreview/reviewmate/domain/review/ReviewImageRepository.java
@@ -12,8 +12,13 @@ import java.util.List;
 @Repository
 public interface ReviewImageRepository extends JpaRepository<ReviewImage, Long> {
 
+
+    @Query("select ri from ReviewImage ri where ri.review in :reviews")
+    List<ReviewImage> findReviewImagesByReviewIdsInQuery(List<Review> reviews);
+
+
     @Transactional
     @Modifying
-    @Query("delete from ReviewImage ri where ri.review.id in :ids")
-    void deleteAllByReviewIdInQuery(List<Long> ids);
+    @Query("delete from ReviewImage ri where ri.review in :reviews")
+    void deleteAllByReviewsInQuery(List<Review> reviews);
 }

--- a/src/main/java/com/somartreview/reviewmate/domain/review/ReviewJpaRepository.java
+++ b/src/main/java/com/somartreview/reviewmate/domain/review/ReviewJpaRepository.java
@@ -1,8 +1,11 @@
 package com.somartreview.reviewmate.domain.review;
 
+import com.somartreview.reviewmate.domain.reservation.Reservation;
 import com.somartreview.reviewmate.dto.review.ReviewTagStatisticsDto;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Optional;
@@ -12,7 +15,19 @@ public interface ReviewJpaRepository extends JpaRepository<Review, Long> {
 
     boolean existsByReservation_Id(Long reservationId);
 
-    List<Review> findAllByReservation_TravelProduct_PartnerCompany_PartnerDomainAndReservation_TravelProduct_PartnerCustomId(String partnerDomain, String partnerCustomId);
+
+    @Query("select count(r.id) from Review r join r.reservation.travelProduct.partnerCompany c " +
+            "where r.reservation.travelProduct.partnerCompany.partnerDomain = :partnerDomain")
+    Long countByPartnerDomain(String partnerDomain);
+
+
+    @Query("select count(r.id) from Review r where r.reservation in :reservations")
+    Long countByReservations(List<Reservation> reservation);
+
+
+    @Query("select r from Review r where r.reservation in :reservations")
+    List<Review> findAllByReservation(List<Reservation> reservations);
+
 
     @Query("SELECT new com.somartreview.reviewmate.dto.review.ReviewTagStatisticsDto(rt.reviewProperty, rt.polarity, COUNT(rt)) " +
             "FROM ReviewTag rt " +
@@ -20,6 +35,4 @@ public interface ReviewJpaRepository extends JpaRepository<Review, Long> {
             "WHERE rt.review.reservation.travelProduct.id = :travelProductId " +
             "GROUP BY rt.reviewProperty, rt.polarity")
     List<ReviewTagStatisticsDto> findReviewTagStatisticsByTravelProductId(Long travelProductId);
-
-    Optional<Review> findByReservation_Id(Long reservationId);
 }

--- a/src/main/java/com/somartreview/reviewmate/domain/review/ReviewRepository.java
+++ b/src/main/java/com/somartreview/reviewmate/domain/review/ReviewRepository.java
@@ -1,23 +1,7 @@
 package com.somartreview.reviewmate.domain.review;
 
-import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
-import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
 
 @Repository
 public interface ReviewRepository extends ReviewJpaRepository, ReviewCustomRepository {
-
-    Long findIdByReservationId(Long reservationId);
-
-    @Query("select count(r.id) from Review r join r.reservation.travelProduct.partnerCompany c " +
-            "where r.reservation.travelProduct.partnerCompany.partnerDomain = :partnerDomain")
-    Long countByPartnerDomain(String partnerDomain);
-
-    @Transactional
-    @Modifying
-    @Query("delete from Review r where r.id in :ids")
-    void deleteAllByIdsInQuery(List<Long> ids);
 }

--- a/src/main/java/com/somartreview/reviewmate/domain/review/ReviewTagRepository.java
+++ b/src/main/java/com/somartreview/reviewmate/domain/review/ReviewTagRepository.java
@@ -13,8 +13,9 @@ public interface ReviewTagRepository extends JpaRepository<ReviewTag, Long>, Rev
 
     List<ReviewTag> findAllByReview_Id(Long reviewId);
 
+
     @Transactional
     @Modifying
-    @Query("delete from ReviewTag rt where rt.review.id in :ids")
-    void deleteAllByReviewIdInQuery(List<Long> ids);
+    @Query("delete from ReviewTag rt where rt.review in :reviews")
+    void deleteAllByReviewsInQuery(List<Review> reviews);
 }

--- a/src/main/java/com/somartreview/reviewmate/dto/review/WidgetReviewResponse.java
+++ b/src/main/java/com/somartreview/reviewmate/dto/review/WidgetReviewResponse.java
@@ -2,13 +2,14 @@ package com.somartreview.reviewmate.dto.review;
 
 import com.somartreview.reviewmate.domain.review.Review;
 import com.somartreview.reviewmate.domain.review.ReviewPolarity;
-import com.somartreview.reviewmate.domain.review.ReviewTag;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.util.List;
+
+import static com.somartreview.reviewmate.service.review.ReviewImageService.CDN_DOMAIN;
 
 @Getter
 @NoArgsConstructor
@@ -33,6 +34,9 @@ public class WidgetReviewResponse {
     @Schema(description = "업로드 날짜", example = "2021.01.01")
     private String createdAt;
 
+    @Schema(description = "리뷰 사진 URL", example = "https://image.reviewmate.co.kr/image.png")
+    private List<String> reviewImageUrls;
+
     @Schema(description = "긍부정", example = "POSITIVE")
     private ReviewPolarity polarity;
 
@@ -46,6 +50,7 @@ public class WidgetReviewResponse {
         this.content = review.getContent();
         this.authorName = review.getReservation().getCustomer().getName();
         this.createdAt = review.getCreatedAt().toString();
+        this.reviewImageUrls = review.getReviewImages().stream().map(reviewImage -> CDN_DOMAIN + "/" + reviewImage.getFileName()).toList();
         this.polarity = review.getPolarity();
         this.reviewHighlightPairResponses = review.getReviewTags().stream().map(ReviewHighlightPairResponse::new).toList();
     }

--- a/src/main/java/com/somartreview/reviewmate/exception/ErrorCode.java
+++ b/src/main/java/com/somartreview/reviewmate/exception/ErrorCode.java
@@ -54,6 +54,7 @@ public enum ErrorCode {
     REVIEW_TAG_FRONT_END_INDEX_ERROR("1311", "리뷰 태그의 끝 인덱스가 시작 인덱스보다 앞에 있습니다."),
 
     REVIEW_IMAGE_URL_ERROR("1320", "리뷰 이미지의 링크가 너무 길거나 공백입니다."),
+    REVIEW_IMAGE_FILE_IO_ERROR("1321", "리뷰 이미지의 IO 과정에서 오류가 발생했습니다."),
 
     TRAVEL_PRODUCT_THUMBNAIL_URL_ERROR("1400", "여행상품의 썸네일 링크가 너무 길거나 공백입니다."),
     TRAVEL_PRODUCT_NAME_ERROR("1401", "여행상품의 이름이 너무 길거나 공백입니다."),
@@ -73,10 +74,12 @@ public enum ErrorCode {
 
     INVALID_PROPERTY_ERROR("9001", "잘못된 값이 입력되었습니다."),
     MISSED_PARAMETER_ERROR("9002", "필수 파라미터가 누락되었습니다."),
-
     API_NOT_FOUND_ERROR("9006", "요청한 API가 존재하지 않습니다"),
     DB_CONFLICT_ERROR("9007", "요청한 데이터가 데이터베이스와 충돌됩니다."),
     REVIEW_MATE_ERROR("9908", "처리하지 못한 예외입니다."),
+
+    AWS_S3_CLIENT_ERROR("9101", "AWS S3 Client 에러입니다."),
+
     RUNTIME_ERROR("9909", "알 수 없는 예외입니다.");
 
     private final String code;

--- a/src/main/java/com/somartreview/reviewmate/exception/ExternalServiceException.java
+++ b/src/main/java/com/somartreview/reviewmate/exception/ExternalServiceException.java
@@ -1,0 +1,15 @@
+package com.somartreview.reviewmate.exception;
+
+import lombok.Getter;
+
+@Getter
+public class ExternalServiceException extends ReviewMateException {
+
+    public ExternalServiceException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public ExternalServiceException(ErrorCode errorCode, String message) {
+        super(errorCode, message);
+    }
+}

--- a/src/main/java/com/somartreview/reviewmate/service/ReservationDeleteService.java
+++ b/src/main/java/com/somartreview/reviewmate/service/ReservationDeleteService.java
@@ -28,19 +28,10 @@ public class ReservationDeleteService {
         validateExistId(id);
         Reservation reservation = reservationRepository.findById(id).get();
 
+        reviewGlobalDeleteService.deleteAllByReservations(List.of(reservation));
+        liveSatisfactionDeleteService.deleteAllByReservations(List.of(reservation));
+        liveFeedbackDeleteService.deleteAllByReservations(List.of(reservation));
         reservationRepository.deleteById(id);
-
-        if (reservation.getLiveSatisfaction() != null) {
-            liveSatisfactionDeleteService.deleteById(reservation.getLiveSatisfaction().getId());
-        }
-
-        if (reservation.getLiveFeedback() != null) {
-            liveFeedbackDeleteService.deleteById(reservation.getLiveFeedback().getId());
-        }
-
-        if (reservation.getReview() != null) {
-            reviewGlobalDeleteService.deleteById(reservation.getReview().getId());
-        }
     }
 
 
@@ -54,13 +45,10 @@ public class ReservationDeleteService {
     @Transactional
     public void deleteAllByTravelProductId(Long travelProductId) {
         List<Reservation> reservations = reservationRepository.findAllByTravelProductId(travelProductId);
-        List<Long> reviewIds = reservations.stream().map(r -> r.getReview().getId()).toList();
-        List<Long> liveSatisfactionIds = reservations.stream().map(r -> r.getLiveSatisfaction().getId()).toList();
-        List<Long> liveFeedbackIds = reservations.stream().map(r -> r.getLiveFeedback().getId()).toList();
 
+        reviewGlobalDeleteService.deleteAllByReservations(reservations);
+        liveSatisfactionDeleteService.deleteAllByReservations(reservations);
+        liveFeedbackDeleteService.deleteAllByReservations(reservations);
         reservationRepository.deleteAllByTravelProductId(travelProductId);
-        reviewGlobalDeleteService.deleteAllByIds(reviewIds);
-        liveSatisfactionDeleteService.deleteAllByIds(liveSatisfactionIds);
-        liveFeedbackDeleteService.deleteAllByIds(liveFeedbackIds);
     }
 }

--- a/src/main/java/com/somartreview/reviewmate/service/live/LiveFeedbackDeleteService.java
+++ b/src/main/java/com/somartreview/reviewmate/service/live/LiveFeedbackDeleteService.java
@@ -1,6 +1,7 @@
 package com.somartreview.reviewmate.service.live;
 
 import com.somartreview.reviewmate.domain.live.feedback.LiveFeedbackRepository;
+import com.somartreview.reviewmate.domain.reservation.Reservation;
 import com.somartreview.reviewmate.exception.DomainLogicException;
 import com.somartreview.reviewmate.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
@@ -30,7 +31,7 @@ public class LiveFeedbackDeleteService {
     }
 
     @Transactional
-    public void deleteAllByIds(List<Long> ids) {
-        liveFeedbackRepository.deleteAllByIdsInQuery(ids);
+    public void deleteAllByReservations(List<Reservation> reservations) {
+        liveFeedbackRepository.deleteAllByReservationsInQuery(reservations);
     }
 }

--- a/src/main/java/com/somartreview/reviewmate/service/live/LiveSatisfactionDeleteService.java
+++ b/src/main/java/com/somartreview/reviewmate/service/live/LiveSatisfactionDeleteService.java
@@ -1,6 +1,7 @@
 package com.somartreview.reviewmate.service.live;
 
 import com.somartreview.reviewmate.domain.live.satisfaction.LiveSatisfactionRepository;
+import com.somartreview.reviewmate.domain.reservation.Reservation;
 import com.somartreview.reviewmate.exception.DomainLogicException;
 import com.somartreview.reviewmate.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
@@ -18,19 +19,19 @@ public class LiveSatisfactionDeleteService {
 
     @Transactional
     public void deleteById(Long id) {
-        validateExistId(id);
+        validateExistById(id);
 
         liveSatisfactionRepository.deleteById(id);
     }
 
-    private void validateExistId(Long id) {
+    private void validateExistById(Long id) {
         if (!liveSatisfactionRepository.existsById(id)) {
             throw new DomainLogicException(ErrorCode.LIVE_SATISFACTION_NOT_FOUND);
         }
     }
 
     @Transactional
-    public void deleteAllByIds(List<Long> ids) {
-        liveSatisfactionRepository.deleteAllByIdsInQuery(ids);
+    public void deleteAllByReservations(List<Reservation> reservations) {
+        liveSatisfactionRepository.deleteAllByReservationsInQuery(reservations);
     }
 }

--- a/src/main/java/com/somartreview/reviewmate/service/partners/console/PartnerDashboardService.java
+++ b/src/main/java/com/somartreview/reviewmate/service/partners/console/PartnerDashboardService.java
@@ -2,6 +2,7 @@ package com.somartreview.reviewmate.service.partners.console;
 
 import com.somartreview.reviewmate.domain.partner.console.ConsoleTimeSeriesUnit;
 import com.somartreview.reviewmate.domain.product.SingleTravelProductCategory;
+import com.somartreview.reviewmate.domain.reservation.Reservation;
 import com.somartreview.reviewmate.domain.reservation.ReservationRepository;
 import com.somartreview.reviewmate.domain.review.ReviewRepository;
 import com.somartreview.reviewmate.dto.partner.console.*;
@@ -28,15 +29,15 @@ public class PartnerDashboardService {
 
     public Float getReviewingRate(String partnerDomain, LocalDateTime dateTime, ConsoleTimeSeriesUnit timeSeriesUnit) {
         LocalDateTime startDateTime = getStartDateTimeOfTimeSeriesUnit(dateTime, timeSeriesUnit);
-        List<Long> reviewFks = reservationRepository.findAllReviewFKsByCreatedAtGreaterThanEqual(partnerDomain, startDateTime);
+        List<Reservation> reservations = reservationRepository.findAllByCreatedAtGreaterThanEqual(partnerDomain, startDateTime);
 
-        long todayReservationCount = reviewFks.size();
-        if (todayReservationCount == 0) {
+        long reservationCount = reservations.size();
+        if (reservationCount == 0) {
             return 0f;
         }
 
-        long todayReviewCount = reviewFks.stream().filter(Objects::nonNull).count();
-        return (float) todayReviewCount / todayReservationCount * 100;
+        long reviewCount = reviewRepository.countByReservations(reservations);
+        return (float) reviewCount / reservationCount * 100;
     }
 
     private LocalDateTime getStartDateTimeOfTimeSeriesUnit(LocalDateTime dateTime, ConsoleTimeSeriesUnit timeSeriesUnit) {
@@ -86,15 +87,15 @@ public class PartnerDashboardService {
     }
 
     public Float getReviewingRate(String partnerDomain, SingleTravelProductCategory category, LocalDateTime startDateTime, LocalDateTime endDateTime) {
-        List<Long> reviewFks = reservationRepository.findAllReviewFKsByCategoryAndCreatedAtBetween(partnerDomain, category, startDateTime, endDateTime);
+        List<Reservation> reservations = reservationRepository.findAllByCategoryAndCreatedAtBetween(partnerDomain, category, startDateTime, endDateTime);
 
-        long todayReservationCount = reviewFks.size();
-        if (todayReservationCount == 0) {
+        long reservationCount = reservations.size();
+        if (reservationCount == 0) {
             return 0f;
         }
 
-        long todayReviewCount = reviewFks.stream().filter(Objects::nonNull).count();
-        return (float) todayReviewCount / todayReservationCount * 100;
+        long reviewCount = reviewRepository.countByReservations(reservations);
+        return (float) reviewCount / reservationCount * 100;
     }
 
 
@@ -122,15 +123,15 @@ public class PartnerDashboardService {
     }
 
     private Float getReviewingRate(String partnerDomain, LocalDateTime startDateTime, LocalDateTime endDateTime) {
-        List<Long> reviewFks = reservationRepository.findAllReviewFKsByCreatedAtBetween(partnerDomain, startDateTime, endDateTime);
+        List<Reservation> reservations = reservationRepository.findAllByCreatedAtBetween(partnerDomain, startDateTime, endDateTime);
 
-        long todayReservationCount = reviewFks.size();
-        if (todayReservationCount == 0) {
+        long reservationCount = reservations.size();
+        if (reservationCount == 0) {
             return 0f;
         }
 
-        long todayReviewCount = reviewFks.stream().filter(Objects::nonNull).count();
-        return (float) todayReviewCount / todayReservationCount * 100;
+        long reviewCount = reviewRepository.countByReservations(reservations);
+        return (float) reviewCount / reservationCount * 100;
     }
 
     public ReviewingAchievementBarChartResponse getReviewingAchievementBarChart(String partnerDomain) {

--- a/src/main/java/com/somartreview/reviewmate/service/review/ReviewGlobalDeleteService.java
+++ b/src/main/java/com/somartreview/reviewmate/service/review/ReviewGlobalDeleteService.java
@@ -34,8 +34,18 @@ public class ReviewGlobalDeleteService {
 
     @Transactional
     public void deleteAllByIds(List<Long> ids) {
-        reviewTagRepository.deleteAllByReviewIdInQuery(ids);
-        reviewImageRepository.deleteAllByReviewIdInQuery(ids);
+        deleteAllReviewTagsByIds(ids);
+        deleteAllReviewImagesByIds(ids);
         reviewRepository.deleteAllByIdsInQuery(ids);
+    }
+
+    @Transactional
+    public void deleteAllReviewTagsByIds(List<Long> ids) {
+        reviewTagRepository.deleteAllByReviewIdInQuery(ids);
+    }
+
+    @Transactional
+    public void deleteAllReviewImagesByIds(List<Long> ids) {
+        reviewImageRepository.deleteAllByReviewIdInQuery(ids);
     }
 }

--- a/src/main/java/com/somartreview/reviewmate/service/review/ReviewGlobalDeleteService.java
+++ b/src/main/java/com/somartreview/reviewmate/service/review/ReviewGlobalDeleteService.java
@@ -1,8 +1,7 @@
 package com.somartreview.reviewmate.service.review;
 
-import com.somartreview.reviewmate.domain.review.ReviewImageRepository;
-import com.somartreview.reviewmate.domain.review.ReviewRepository;
-import com.somartreview.reviewmate.domain.review.ReviewTagRepository;
+import com.somartreview.reviewmate.domain.reservation.Reservation;
+import com.somartreview.reviewmate.domain.review.*;
 import com.somartreview.reviewmate.exception.DomainLogicException;
 import com.somartreview.reviewmate.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
@@ -10,6 +9,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -18,34 +18,48 @@ public class ReviewGlobalDeleteService {
     private final ReviewRepository reviewRepository;
     private final ReviewTagRepository reviewTagRepository;
     private final ReviewImageRepository reviewImageRepository;
+    private final ReviewImageService reviewImageService;
 
     @Transactional
-    public void deleteById(Long id) {
-        validateExistId(id);
+    public void deleteReviewByReviewId(Long reviewId) {
+        Review review = validateExistId(reviewId);
 
-        deleteAllByIds(List.of(id));
+        deleteReviewCascade(List.of(review));
+        reviewRepository.deleteById(reviewId);
     }
 
-    private void validateExistId(Long id) {
-        if (!reviewRepository.existsById(id)) {
+    private Review validateExistId(Long reviewId) {
+        Optional<Review> review = reviewRepository.findById(reviewId);
+        if (review.isEmpty()) {
             throw new DomainLogicException(ErrorCode.REVIEW_NOT_FOUND);
         }
+
+        return review.get();
     }
 
     @Transactional
-    public void deleteAllByIds(List<Long> ids) {
-        deleteAllReviewTagsByIds(ids);
-        deleteAllReviewImagesByIds(ids);
-        reviewRepository.deleteAllByIdsInQuery(ids);
+    public void deleteAllByReservations(List<Reservation> reservations) {
+        List<Review> reviews = reviewRepository.findAllByReservation(reservations);
+
+        deleteReviewCascade(reviews);
+        reviewRepository.deleteAllInBatch(reviews);
+    }
+
+    private void deleteReviewCascade(List<Review> reviews) {
+        deleteReviewTagsByReviews(reviews);
+        deleteReviewImagesByReviews(reviews);
     }
 
     @Transactional
-    public void deleteAllReviewTagsByIds(List<Long> ids) {
-        reviewTagRepository.deleteAllByReviewIdInQuery(ids);
+    public void deleteReviewTagsByReviews(List<Review> reviews) {
+        reviewTagRepository.deleteAllByReviewsInQuery(reviews);
     }
 
     @Transactional
-    public void deleteAllReviewImagesByIds(List<Long> ids) {
-        reviewImageRepository.deleteAllByReviewIdInQuery(ids);
+    public void deleteReviewImagesByReviews(List<Review> reviews) {
+        List<ReviewImage> reviewImages = reviewImageRepository.findReviewImagesByReviewIdsInQuery(reviews);
+        reviewImageService.removeReviewImageFiles(reviewImages);
+
+        reviewImageRepository.deleteAllByReviewsInQuery(reviews);
     }
 }

--- a/src/main/java/com/somartreview/reviewmate/service/review/ReviewImageService.java
+++ b/src/main/java/com/somartreview/reviewmate/service/review/ReviewImageService.java
@@ -23,13 +23,13 @@ import static com.somartreview.reviewmate.exception.ErrorCode.REVIEW_IMAGE_FILE_
 @Service
 @RequiredArgsConstructor
 public class ReviewImageService {
+    public static String CDN_DOMAIN = "image.reviewmate.co.kr";
 
     private final ReviewImageRepository reviewImageRepository;
     private final AmazonS3Client amazonS3Client;
 
     @Value("${cloud.aws.s3.bucket}")
     private String s3ImageBucketName;
-    public static String CDN_DOMAIN = "image.reviewmate.co.kr";
 
 
     public void createAll(List<MultipartFile> reviewImageFiles, Review review) {
@@ -45,7 +45,7 @@ public class ReviewImageService {
 
     private String uploadReviewImageFilesOnS3(MultipartFile reviewImage) {
         try {
-            String fileName = reviewImage.getOriginalFilename();
+            String fileName = reviewImage.getOriginalFilename() + "_" + System.currentTimeMillis();
             ObjectMetadata metadata = new ObjectMetadata();
             metadata.setContentType(reviewImage.getContentType());
             metadata.setContentLength(reviewImage.getSize());

--- a/src/main/java/com/somartreview/reviewmate/service/review/ReviewImageService.java
+++ b/src/main/java/com/somartreview/reviewmate/service/review/ReviewImageService.java
@@ -33,7 +33,7 @@ public class ReviewImageService {
     public void createAll(List<MultipartFile> reviewImageFiles, Review review) {
         for (MultipartFile reviewImageFile : reviewImageFiles) {
             ReviewImage reviewImage = ReviewImage.builder()
-                    .fileName(uploadReviewImageOnS3(reviewImageFile))
+                    .fileName(uploadReviewImageFilesOnS3(reviewImageFile))
                     .review(review)
                     .build();
 
@@ -41,7 +41,7 @@ public class ReviewImageService {
         }
     }
 
-    private String uploadReviewImageOnS3(MultipartFile reviewImage) {
+    private String uploadReviewImageFilesOnS3(MultipartFile reviewImage) {
         try {
             String fileName = reviewImage.getOriginalFilename();
             ObjectMetadata metadata = new ObjectMetadata();
@@ -58,13 +58,13 @@ public class ReviewImageService {
         }
     }
 
-    public void deleteAll(List<ReviewImage> reviewImages) {
+    public void removeReviewImageFiles(List<ReviewImage> reviewImages) {
         for (ReviewImage reviewImage : reviewImages) {
-            deleteReviewImageOnS3(reviewImage.getFileName());
+            removeReviewImageFilesOnS3(reviewImage.getFileName());
         }
     }
 
-    private void deleteReviewImageOnS3(String fileName) {
+    private void removeReviewImageFilesOnS3(String fileName) {
         try {
             amazonS3Client.deleteObject(s3ImageBucketName, fileName);
 

--- a/src/main/java/com/somartreview/reviewmate/service/review/ReviewImageService.java
+++ b/src/main/java/com/somartreview/reviewmate/service/review/ReviewImageService.java
@@ -9,6 +9,7 @@ import com.somartreview.reviewmate.domain.review.ReviewImageRepository;
 import com.somartreview.reviewmate.exception.DomainLogicException;
 import com.somartreview.reviewmate.exception.ExternalServiceException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
@@ -28,6 +29,7 @@ public class ReviewImageService {
 
     @Value("${cloud.aws.s3.bucket}")
     private String s3ImageBucketName;
+    public static String CDN_DOMAIN = "image.reviewmate.co.kr";
 
 
     public void createAll(List<MultipartFile> reviewImageFiles, Review review) {

--- a/src/main/java/com/somartreview/reviewmate/service/review/ReviewImageService.java
+++ b/src/main/java/com/somartreview/reviewmate/service/review/ReviewImageService.java
@@ -1,0 +1,75 @@
+package com.somartreview.reviewmate.service.review;
+
+import com.amazonaws.SdkClientException;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.somartreview.reviewmate.domain.review.Review;
+import com.somartreview.reviewmate.domain.review.ReviewImage;
+import com.somartreview.reviewmate.domain.review.ReviewImageRepository;
+import com.somartreview.reviewmate.exception.DomainLogicException;
+import com.somartreview.reviewmate.exception.ExternalServiceException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.List;
+
+import static com.somartreview.reviewmate.exception.ErrorCode.AWS_S3_CLIENT_ERROR;
+import static com.somartreview.reviewmate.exception.ErrorCode.REVIEW_IMAGE_FILE_IO_ERROR;
+
+@Service
+@RequiredArgsConstructor
+public class ReviewImageService {
+
+    private final ReviewImageRepository reviewImageRepository;
+    private final AmazonS3Client amazonS3Client;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String s3ImageBucketName;
+
+
+    public void createAll(List<MultipartFile> reviewImageFiles, Review review) {
+        for (MultipartFile reviewImageFile : reviewImageFiles) {
+            ReviewImage reviewImage = ReviewImage.builder()
+                    .fileName(uploadReviewImageOnS3(reviewImageFile))
+                    .review(review)
+                    .build();
+
+            reviewImageRepository.save(reviewImage);
+        }
+    }
+
+    private String uploadReviewImageOnS3(MultipartFile reviewImage) {
+        try {
+            String fileName = reviewImage.getOriginalFilename();
+            ObjectMetadata metadata = new ObjectMetadata();
+            metadata.setContentType(reviewImage.getContentType());
+            metadata.setContentLength(reviewImage.getSize());
+
+            amazonS3Client.putObject(s3ImageBucketName, fileName, reviewImage.getInputStream(), metadata);
+            return fileName;
+
+        } catch (SdkClientException e) {
+            throw new ExternalServiceException(AWS_S3_CLIENT_ERROR);
+        } catch (IOException e) {
+            throw new DomainLogicException(REVIEW_IMAGE_FILE_IO_ERROR);
+        }
+    }
+
+    public void deleteAll(List<ReviewImage> reviewImages) {
+        for (ReviewImage reviewImage : reviewImages) {
+            deleteReviewImageOnS3(reviewImage.getFileName());
+        }
+    }
+
+    private void deleteReviewImageOnS3(String fileName) {
+        try {
+            amazonS3Client.deleteObject(s3ImageBucketName, fileName);
+
+        } catch (SdkClientException e) {
+            throw new ExternalServiceException(AWS_S3_CLIENT_ERROR);
+        }
+    }
+}

--- a/src/main/java/com/somartreview/reviewmate/service/review/ReviewService.java
+++ b/src/main/java/com/somartreview/reviewmate/service/review/ReviewService.java
@@ -29,9 +29,12 @@ import static com.somartreview.reviewmate.exception.ErrorCode.REVIEW_NOT_FOUND;
 public class ReviewService {
 
     private final ReviewRepository reviewRepository;
+    private final ReviewImageService reviewImageService;
     private final ReviewTagService reviewTagService;
+    private final ReviewGlobalDeleteService reviewGlobalDeleteService;
     private final ReservationService reservationService;
     private final SingleTravelProductService singleTravelProductService;
+
 
     @Transactional
     public Long create(String partnerDomain, String travelProductPartnerCustomId, ReviewCreateRequest reviewCreateRequest, List<MultipartFile> reviewImageFiles) {
@@ -40,13 +43,11 @@ public class ReviewService {
 
         Review review = reviewCreateRequest.toEntity(reservation);
         reviewRepository.save(review);
-
-        reservation.getTravelProduct().updateReviewData(review.getRating());
+        reservation.getTravelProduct().addReviewInfo(review.getRating());
         reservation.addReview(review);
 
         if (reviewImageFiles != null) {
-            List<ReviewImage> reviewImages = createReviewImages(reviewImageFiles, review);
-            review.appendReviewImage(reviewImages);
+            reviewImageService.createAll(reviewImageFiles, review);
         }
 
         // Impl Requesting review inference through API gateway
@@ -58,20 +59,6 @@ public class ReviewService {
     private void validateExistReviewByReservationId(Long reservationId) {
         if (reviewRepository.existsByReservation_Id(reservationId))
             throw new DomainLogicException(REVIEW_ALREADY_EXISTS_ON_RESERVATION);
-    }
-
-    private List<ReviewImage> createReviewImages(List<MultipartFile> reviewImageFiles, Review review) {
-        return reviewImageFiles.stream()
-                .map(reviewImageFile -> ReviewImage.builder()
-                        .url(uploadReviewImageOnS3(reviewImageFile))
-                        .review(review)
-                        .build())
-                .toList();
-    }
-
-    private String uploadReviewImageOnS3(MultipartFile reviewImage) {
-        //  Impl uploading review image to S3 and get the url
-        return "https://www.testThumbnailUrl.com";
     }
 
     public Review findById(Long id) {
@@ -146,14 +133,17 @@ public class ReviewService {
     public void update(Long id, ReviewUpdateRequest request, List<MultipartFile> reviewImageFiles) {
         Review review = findById(id);
 
-        review.getReservation().getTravelProduct().removeReviewData(review.getRating());
-        review.clearReviewTags();
+        review.getReservation().getTravelProduct().substractReviewInfo(review.getRating());
+        List<Long> ids = List.of(review.getId());
+        reviewImageService.deleteAll(review.getReviewImages());
         review.clearReviewImages();
+        reviewGlobalDeleteService.deleteAllReviewImagesByIds(ids);
+        review.clearReviewTags();
+        reviewGlobalDeleteService.deleteAllReviewTagsByIds(ids);
 
         review.updateReview(request);
-        review.getReservation().getTravelProduct().updateReviewData(request.getRating());
-        List<ReviewImage> reviewImages = createReviewImages(reviewImageFiles, review);
-        review.appendReviewImage(reviewImages);
+        review.getReservation().getTravelProduct().addReviewInfo(request.getRating());
+        reviewImageService.createAll(reviewImageFiles, review);
 
         // Impl Requesting review inference through API gateway
         // Impl Requesting review inference through kafka

--- a/src/main/java/com/somartreview/reviewmate/service/review/ReviewService.java
+++ b/src/main/java/com/somartreview/reviewmate/service/review/ReviewService.java
@@ -8,6 +8,7 @@ import com.somartreview.reviewmate.exception.DomainLogicException;
 import com.somartreview.reviewmate.service.ReservationService;
 import com.somartreview.reviewmate.service.products.SingleTravelProductService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;

--- a/src/main/java/com/somartreview/reviewmate/service/review/ReviewService.java
+++ b/src/main/java/com/somartreview/reviewmate/service/review/ReviewService.java
@@ -44,7 +44,6 @@ public class ReviewService {
         Review review = reviewCreateRequest.toEntity(reservation);
         reviewRepository.save(review);
         reservation.getTravelProduct().addReviewInfo(review.getRating());
-        reservation.addReview(review);
 
         if (reviewImageFiles != null) {
             reviewImageService.createAll(reviewImageFiles, review);
@@ -134,12 +133,11 @@ public class ReviewService {
         Review review = findById(id);
 
         review.getReservation().getTravelProduct().substractReviewInfo(review.getRating());
-        List<Long> ids = List.of(review.getId());
-        reviewImageService.deleteAll(review.getReviewImages());
+        List<Review> reviews = List.of(review);
         review.clearReviewImages();
-        reviewGlobalDeleteService.deleteAllReviewImagesByIds(ids);
+        reviewGlobalDeleteService.deleteReviewImagesByReviews(reviews);
         review.clearReviewTags();
-        reviewGlobalDeleteService.deleteAllReviewTagsByIds(ids);
+        reviewGlobalDeleteService.deleteReviewTagsByReviews(reviews);
 
         review.updateReview(request);
         review.getReservation().getTravelProduct().addReviewInfo(request.getRating());

--- a/src/main/java/com/somartreview/reviewmate/web/review/ReviewBasicWidgetController.java
+++ b/src/main/java/com/somartreview/reviewmate/web/review/ReviewBasicWidgetController.java
@@ -106,7 +106,7 @@ public class ReviewBasicWidgetController {
     @ApiResponse(responseCode = "400", description = "존재하지 않는 리뷰 ID")
     @DeleteMapping("/reviews/{reviewId}")
     public ResponseEntity<Void> deleteReviewByReviewId(@PathVariable Long reviewId) {
-        reviewGlobalDeleteService.deleteById(reviewId);
+        reviewGlobalDeleteService.deleteReviewByReviewId(reviewId);
 
         return ResponseEntity.noContent().build();
     }

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -37,7 +37,7 @@ VALUES ('2023-10-17 12:00:00', '2023-10-17 12:00:00', 'POSITIVE', '리뷰 내용
 INSERT INTO review_tag (created_at, updated_at, keyword, polarity, property, start_index, end_index, review_id)
 VALUES ('2023-10-17 12:00:00', '2023-10-17 12:00:00', '먼지', 'NEGATIVE', 'CLEANNESS', 0, 1, 1);
 
-INSERT INTO review_image (created_at, updated_at, url, review_id)
+INSERT INTO review_image (created_at, updated_at, file_name, review_id)
 VALUES ('2023-10-17 12:00:00', '2023-10-17 12:00:00', 'testurl.com', 1);
 
 

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -28,11 +28,11 @@ VALUES ('SingleTravelProduct', '2023-10-17 12:00:00', '2023-10-17 12:00:00', '�
 --  Review  #####################################################################################################################################################################################################################
 --  Review  #####################################################################################################################################################################################################################
 
-INSERT INTO reservation (created_at, updated_at, partner_custom_id, start_date_time, end_date_time, customer_id, travel_product_id, review_id, live_satisfaction_id, live_feedback_id)
-VALUES ('2023-10-17 12:00:00', '2023-10-17 12:00:00', 'RESERVATION_0001', '2023-10-18T13:00:00', '2023-10-19T12:00:00', 1, 1, null, null, null);
+INSERT INTO reservation (created_at, updated_at, partner_custom_id, start_date_time, end_date_time, customer_id, travel_product_id)
+VALUES ('2023-10-17 12:00:00', '2023-10-17 12:00:00', 'RESERVATION_0001', '2023-10-18T13:00:00', '2023-10-19T12:00:00', 1, 1);
 
-INSERT INTO review (created_at, updated_at, polarity, content, rating, title, positive_tags_count, negative_tags_count)
-VALUES ('2023-10-17 12:00:00', '2023-10-17 12:00:00', 'POSITIVE', '리뷰 내용 1', 3, '리뷰 제목 1', 0, 1);
+INSERT INTO review (created_at, updated_at, polarity, content, rating, title, positive_tags_count, negative_tags_count, reservation_id)
+VALUES ('2023-10-17 12:00:00', '2023-10-17 12:00:00', 'POSITIVE', '리뷰 내용 1', 3, '리뷰 제목 1', 0, 1, 1);
 
 INSERT INTO review_tag (created_at, updated_at, keyword, polarity, property, start_index, end_index, review_id)
 VALUES ('2023-10-17 12:00:00', '2023-10-17 12:00:00', '먼지', 'NEGATIVE', 'CLEANNESS', 0, 1, 1);
@@ -42,14 +42,11 @@ VALUES ('2023-10-17 12:00:00', '2023-10-17 12:00:00', 'testurl.com', 1);
 
 
 
-INSERT INTO reservation (created_at, updated_at, partner_custom_id, start_date_time, end_date_time, customer_id, travel_product_id, review_id, live_satisfaction_id, live_feedback_id)
-VALUES ('2023-10-17 12:00:00', '2023-10-17 12:00:00', 'RESERVATION_0002', '2023-10-18T13:00:00', '2023-10-19T12:00:00', 1, 1, null, null, null);
+INSERT INTO reservation (created_at, updated_at, partner_custom_id, start_date_time, end_date_time, customer_id, travel_product_id)
+VALUES ('2023-10-17 12:00:00', '2023-10-17 12:00:00', 'RESERVATION_0002', '2023-10-18T13:00:00', '2023-10-19T12:00:00', 1, 1);
 
-INSERT INTO review (created_at, updated_at, polarity, content, rating, title, positive_tags_count, negative_tags_count)
-VALUES ('2023-10-17 12:00:00', '2023-10-17 12:00:00', 'POSITIVE', '리뷰 내용 1', 5, '리뷰 제목 1', 0, 3);
-
-INSERT INTO review_tag (created_at, updated_at, keyword, polarity, property, start_index, end_index, review_id)
-VALUES ('2023-10-17 12:00:00', '2023-10-17 12:00:00', '냄새', 'NEGATIVE', 'CLEANNESS', 0, 2, 2);
+INSERT INTO review (created_at, updated_at, polarity, content, rating, title, positive_tags_count, negative_tags_count, reservation_id)
+VALUES ('2023-10-17 12:00:00', '2023-10-17 12:00:00', 'POSITIVE', '리뷰 내용 1', 5, '리뷰 제목 1', 0, 3, 2);
 
 INSERT INTO review_tag (created_at, updated_at, keyword, polarity, property, start_index, end_index, review_id)
 VALUES ('2023-10-17 12:00:00', '2023-10-17 12:00:00', '냄새', 'NEGATIVE', 'CLEANNESS', 0, 2, 2);
@@ -57,13 +54,16 @@ VALUES ('2023-10-17 12:00:00', '2023-10-17 12:00:00', '냄새', 'NEGATIVE', 'CLE
 INSERT INTO review_tag (created_at, updated_at, keyword, polarity, property, start_index, end_index, review_id)
 VALUES ('2023-10-17 12:00:00', '2023-10-17 12:00:00', '냄새', 'NEGATIVE', 'CLEANNESS', 0, 2, 2);
 
+INSERT INTO review_tag (created_at, updated_at, keyword, polarity, property, start_index, end_index, review_id)
+VALUES ('2023-10-17 12:00:00', '2023-10-17 12:00:00', '냄새', 'NEGATIVE', 'CLEANNESS', 0, 2, 2);
 
 
-INSERT INTO reservation (created_at, updated_at, partner_custom_id, start_date_time, end_date_time, customer_id, travel_product_id, review_id, live_satisfaction_id, live_feedback_id)
-VALUES ('2023-10-01 12:00:00', '2023-10-01 12:00:00', 'RESERVATION_0003', '2023-10-18T13:00:00', '2023-10-19T12:00:00', 1, 1, null, null, null);
 
-INSERT INTO review (created_at, updated_at, polarity, content, rating, title, positive_tags_count, negative_tags_count)
-VALUES ('2023-10-01 12:00:00', '2023-10-01 12:00:00', 'POSITIVE', '리뷰 내용 1', 4, '리뷰 제목 1', 3, 2);
+INSERT INTO reservation (created_at, updated_at, partner_custom_id, start_date_time, end_date_time, customer_id, travel_product_id)
+VALUES ('2023-10-01 12:00:00', '2023-10-01 12:00:00', 'RESERVATION_0003', '2023-10-18T13:00:00', '2023-10-19T12:00:00', 1, 1);
+
+INSERT INTO review (created_at, updated_at, polarity, content, rating, title, positive_tags_count, negative_tags_count, reservation_id)
+VALUES ('2023-10-01 12:00:00', '2023-10-01 12:00:00', 'POSITIVE', '리뷰 내용 1', 4, '리뷰 제목 1', 3, 2, 3);
 
 INSERT INTO review_tag (created_at, updated_at, keyword, polarity, property, start_index, end_index, review_id)
 VALUES ('2023-10-01 12:00:00', '2023-10-01 12:00:00', '먼지', 'POSITIVE', 'KINDNESS', 0, 3, 3);
@@ -82,8 +82,8 @@ VALUES ('2023-10-01 12:00:00', '2023-10-01 12:00:00', '먼지', 'NEGATIVE', 'KIN
 
 
 
-INSERT INTO reservation (created_at, updated_at, partner_custom_id, start_date_time, end_date_time, customer_id, travel_product_id, review_id, live_satisfaction_id, live_feedback_id)
-VALUES ('2023-10-01 12:00:00', '2023-10-01 12:00:00', 'RESERVATION_0004', '2023-10-18T13:00:00', '2023-10-19T12:00:00', 1, 1, null, null, null);
+INSERT INTO reservation (created_at, updated_at, partner_custom_id, start_date_time, end_date_time, customer_id, travel_product_id)
+VALUES ('2023-10-01 12:00:00', '2023-10-01 12:00:00', 'RESERVATION_0004', '2023-10-18T13:00:00', '2023-10-19T12:00:00', 1, 1);
 
 
 
@@ -91,13 +91,8 @@ VALUES ('2023-10-01 12:00:00', '2023-10-01 12:00:00', 'RESERVATION_0004', '2023-
 --  Live Chatbot  #####################################################################################################################################################################################################
 --  Live Chatbot  #####################################################################################################################################################################################################
 
-INSERT INTO live_feedback (created_at, updated_at, customer_media_url, customer_message, is_handled, is_reported, is_solved, seller_message)
-VALUES ('2023-10-17 12:00:00', '2023-10-17 12:00:00', null, '피드백 메시지 1', 0, 0, 0, '응답 메시지 1');
+INSERT INTO live_feedback (created_at, updated_at, customer_media_url, customer_message, is_handled, is_reported, is_solved, seller_message, reservation_id)
+VALUES ('2023-10-17 12:00:00', '2023-10-17 12:00:00', null, '피드백 메시지 1', 0, 0, 0, '응답 메시지 1', 1);
 
-INSERT INTO live_satisfaction (created_at, updated_at, dissatisfied_review_property, rating, satisfied_review_property)
-VALUES ('2023-10-17 12:00:00', '2023-10-17 12:00:00', 'KINDNESS', 5, 'LOCATION');
-
-
-UPDATE reservation SET review_id = 1, live_satisfaction_id = 1, live_feedback_id = 1 WHERE reservation_id = 1;
-UPDATE reservation SET review_id = 2 WHERE reservation_id = 2;
-UPDATE reservation SET review_id = 3 WHERE reservation_id = 3;
+INSERT INTO live_satisfaction (created_at, updated_at, dissatisfied_review_property, rating, satisfied_review_property, reservation_id)
+VALUES ('2023-10-17 12:00:00', '2023-10-17 12:00:00', 'KINDNESS', 5, 'LOCATION', 1);

--- a/src/test/java/com/somartreview/reviewmate/domain/product/SingleTravelProductTest.java
+++ b/src/test/java/com/somartreview/reviewmate/domain/product/SingleTravelProductTest.java
@@ -126,7 +126,7 @@ class SingleTravelProductTest {
     @Test
     void 단일_여행상품에_리뷰가_추가된다() {
         // given & when
-        singleTravelProduct.updateReviewData(5);
+        singleTravelProduct.addReviewInfo(5);
 
         // then
         assertThat(singleTravelProduct)
@@ -137,9 +137,9 @@ class SingleTravelProductTest {
     @Test
     void 단일_여행상품에_리뷰가_삭제된다() {
         // given & when
-        singleTravelProduct.updateReviewData(5);
-        singleTravelProduct.updateReviewData(5);
-        singleTravelProduct.removeReviewData(5);
+        singleTravelProduct.addReviewInfo(5);
+        singleTravelProduct.addReviewInfo(5);
+        singleTravelProduct.substractReviewInfo(5);
 
         // then
         assertThat(singleTravelProduct)
@@ -150,8 +150,8 @@ class SingleTravelProductTest {
     @Test
     void 단일_여행상품에_리뷰가_삭제될때_리뷰갯수가_0개여도_dividedByZero_예외가_발생하지_않는다() {
         // given & when
-        singleTravelProduct.updateReviewData(5);
-        singleTravelProduct.removeReviewData(5);
+        singleTravelProduct.addReviewInfo(5);
+        singleTravelProduct.substractReviewInfo(5);
 
         // then
         assertThat(singleTravelProduct)


### PR DESCRIPTION
# 요약
미뤄졌던 리뷰 사진 업로드, 수정, 삭제, 조회 기능이 추가됐습니다. AWS S3 bucket을 이용하였고, AWS Cloudfront를 이용해 CDN 또한 구성했습니다. 

- 기존 API에서 비어있던 URL 부분이 구현된 것이므로, 변경 사항은 없습니다. 제공되는 URL을 그대로 이용하면 사진을 조회할 수 있습니다. 리뷰가 수정 및 삭제될 때마다 S3에서 즉시 삭제됩니다.
<img width="655" alt="스크린샷 2023-11-01 03 23 55" src="https://github.com/review-mate/review-mate-be/assets/49567744/72165d39-3583-4e79-ba56-81aad60b1831">

![스크린샷 2023-11-01 03 24 16](https://github.com/review-mate/review-mate-be/assets/49567744/57b554a5-ecf0-4db0-8b11-54bd60ee77c7)

- 리뷰 사진 도메인은 image.reviewmate.co.kr 입니다. WAF 방화벽 설정되어 있으며, 존재하지 않는 파일 도메인으로 접근하면 denied 됩니다.
- 리뷰 사진을 구현하는 과정에서 비효율적이라고 깨달은 Reservaition과 FK 구조를 리팩토링했습니다. 다른 이슈에서 후술하겠습니다.

# 체크리스트
이 PR에는:

- [X] Reservation - Review - LiveFeedback - LiveSatisfaction 관계를 정리
- [X] 리뷰 사진 기능 추가
